### PR TITLE
change writing strategy to avoid partial writes when interrupted

### DIFF
--- a/lib/Config/JSON.pm
+++ b/lib/Config/JSON.pm
@@ -295,28 +295,19 @@ sub write {
     my $to_write = FILE_HEADER . "\n" . $json;
     my $needed_bytes = length $to_write;
 
-    # open as read/write
-    open my $fh, '+<:raw', $realfile or confess "Unable to open $realfile for write: $!";
-    my $current_bytes = (stat $fh)[7];
-    # shrink file if needed
-    if ($needed_bytes < $current_bytes) {
-        truncate $fh, $needed_bytes;
-    }
-    # make sure we can expand the file to the needed size before we overwrite it
-    elsif ($needed_bytes > $current_bytes) {
-        my $padding = q{ } x ($needed_bytes - $current_bytes);
-        sysseek $fh, 0, 2;
-        if (! syswrite $fh, $padding) {
-            sysseek $fh, 0, 0;
-            truncate $fh, $current_bytes;
-            close $fh;
-            confess "Unable to expand $realfile: $!";
-        }
-        sysseek $fh, 0, 0;
-        seek $fh, 0, 0;
-    }
-    print {$fh} $to_write;
-    close $fh;
+    # read the permissions of any current copy of the config file
+    open my $fh, '<', $realfile;
+    my $perm = $fh ? (stat $fh)[2] & 07777 : undef;
+    close $fh if $fh;
+
+    # write new copy of the config file to a tmp file
+    my $tmpfile = "$realfile.tmp.$$";
+    open $fh, '>:raw', $tmpfile or confess "Unable to open '$tmpfile' for write: $!";
+    chmod $perm, $fh if $perm;
+    print {$fh} $to_write or confess "Failed while writing to '$tmpfile'";
+    close $fh or confess "Failed after writing to '$tmpfile'";
+
+    rename $tmpfile, $realfile or confess "Failed to move '$tmpfile' over top of '$realfile'";
 
     return 1;
 }

--- a/t/Write.t
+++ b/t/Write.t
@@ -1,0 +1,50 @@
+use Test::More tests => 7;
+
+use lib '../lib';
+use Test::Deep;
+use Config::JSON;
+use File::Temp qw/ tempfile /;
+
+my ($fh, $filename) = tempfile();
+close($fh);
+my $config = Config::JSON->create($filename);
+ok (defined $config, "create new config");
+
+# set up test data
+if (open(my $file, ">", $filename)) {
+my $testData = <<END;
+# config-file-type: JSON 1
+
+ {
+        "dsn" : "DBI:mysql:test",
+        "user" : "tester",
+        "password" : "xxxxxx", 
+
+        # some colors to choose from
+        "colors" : [ "red", "green", "blue" ]
+
+ } 
+
+END
+	print {$file} $testData;
+	close($file);
+	ok(1, "set up test data");
+} 
+else {
+	ok(0, "set up test data");
+}
+
+$config = Config::JSON->new($filename);
+isa_ok($config, "Config::JSON" );
+
+is( $config->getFilePath, $filename, "getFilePath()" );
+ok( -e $filename, "file exists" );
+my $size_snapshot = -s $filename;
+
+chmod 0675, $filename;  # unlikely permissions
+$config->set('privateArray', ['a', 'b', 'c']);
+
+my $perm = (stat $filename)[2] & 07777;
+is( $perm, 0675, "unlikely permissions preserved" );
+isnt( $size_snapshot, -s $filename, "size changed suggesting the file was written" );
+


### PR DESCRIPTION
File writing was so delicate and careful that I hate to touch it, but there's only
one way to replace a file in an atomic fashion on Unix that I know of.

Twice now I've observed corrupted config files apparently resulting from the program being interrupted part way through re-writing the file.  This changes strategy to use an atomic operation to replace the config file with a rename() after it is completely written.
