### PR TITLE
Moo does not import Carp it would seem

### DIFF
--- a/lib/Config/JSON.pm
+++ b/lib/Config/JSON.pm
@@ -2,6 +2,7 @@ package Config::JSON;
 
 use strict;
 use Moo;
+use Carp;
 use File::Spec;
 use JSON 2.0;
 use List::Util;


### PR DESCRIPTION
Just one more little problem. Carp has to be loaded explicitly. I didn't add it to the prereq because it is core and I don't think version should matter.
